### PR TITLE
a few rather small changes in evse.c

### DIFF
--- a/components/evse/src/evse.c
+++ b/components/evse/src/evse.c
@@ -395,7 +395,7 @@ void evse_process(void)
             }
             // fallthrough
         case EVSE_STATE_C2:
-            if (!enabled || !available || reached_limit) {
+            if (!charging_allowed()) {
                 state = EVSE_STATE_C1;
                 break;
             }
@@ -428,7 +428,7 @@ void evse_process(void)
             }
             // fallthrough
         case EVSE_STATE_D2:
-            if (!enabled || !available || reached_limit) {
+            if (!charging_allowed()) {
                 state = EVSE_STATE_D1;
                 break;
             }

--- a/components/evse/src/evse.c
+++ b/components/evse/src/evse.c
@@ -395,11 +395,6 @@ void evse_process(void)
             }
             // fallthrough
         case EVSE_STATE_C2:
-            if (!charging_allowed()) {
-                state = EVSE_STATE_C1;
-                break;
-            }
-
             switch (pilot_voltage) {
             case PILOT_VOLTAGE_12:
                 state = EVSE_STATE_A;
@@ -428,11 +423,6 @@ void evse_process(void)
             }
             // fallthrough
         case EVSE_STATE_D2:
-            if (!charging_allowed()) {
-                state = EVSE_STATE_D1;
-                break;
-            }
-
             switch (pilot_voltage) {
             case PILOT_VOLTAGE_6:
                 state = charging_allowed() ? EVSE_STATE_C2 : EVSE_STATE_C1;


### PR DESCRIPTION
## Description:

I tried to reduce the number of different condition tests for the state changes, in the context of charging_allowed() and
ended up with quite a few lines less in the code.
Please review my change of the AC-relay turn off condition in C1 and D1, in case of `!available` the behavior will change, i.e. the relay will turn off immediately instead of waiting for the timeout in C1 or D1. From my perspective this is valid, but please check.

**Related issue (if applicable):** fixes # (issue)

## Checklist:
- [X] The pull request is done against the latest master branch
- [X] The code change compiles without warnings
- [X] The code change are formatted (clang-format)

_NOTE: The code change must pass CI. **Your PR cannot be merged unless CI pass**_
