### PR TITLE
[BUGFIX] Newly opened modbus TCP socket overwrites existing connection

### DIFF
--- a/components/protocols/src/modbus_tcp.c
+++ b/components/protocols/src/modbus_tcp.c
@@ -182,8 +182,13 @@ static void tcp_server_task_func(void* param)
                     ESP_LOGW(TAG, "Maximum connection count %d reached", TCP_MAX_CONN);
                     close_conn(&sock);
                 } else {
-                    socks[conn_cout] = sock;
-                    recv_ticks[conn_cout] = xTaskGetTickCount();
+                    for (int i = 0; i < TCP_MAX_CONN; i++) {
+                        if (socks[i] == -1) {
+                            socks[i] = sock;
+                            recv_ticks[i] = xTaskGetTickCount();
+                            break;
+                        }
+                    }
                     conn_cout++;
                 }
             }


### PR DESCRIPTION
## Description:

Hi Miroslav, 

Thank you for your work on this great project. I was facing an issue with Modbus TCP showing _"Maximum connection count 3 reached"_ in the log. I might found a tiny bug in  _modbus_tcp.c_ code. If I understand it correctly, the opened sockets are stored in `socks[3]` array and the `conn_cout` variable contains number of opened connections.

Now, assume the following scenario:
 * Two connections are already opened, socket descriptors are stored in `socks[0] `and `socks[1].` `conn_cout` = 2
 * The first client disconnects, `socks[0]` is invalidated (equals to -1) and `conn_cout` is reduced to 1
 * Now a new client is about to connect, `accept_conn()` returns the socket descriptor that is going to be written to index pointed by `conn_cout`. But  `conn_cout` = 1, which means the new socket overwrites descriptor of already opened connection at `socks[1]`.
 * This somehow breaks the "close if inactive" logic, leading to "Maximum connection count 3 reached" error eventually.

 The proposed fix iterates over `socks` array and find the first available entry to place the new socket to.

## Checklist:
- [x] The pull request is done against the latest master branch
- [x] The code change compiles without warnings
- [x] The code change are formatted (clang-format)
- [ ] New and existing unit tests pass

Plase set Github secret _WOKWI_CLI_TOKEN_ to run CI unit test in Wokwi simulator  (https://docs.wokwi.com/wokwi-ci/github-actions)

_NOTE: The code change must pass CI. **Your PR cannot be merged unless CI pass**_
