### PR TITLE
led: fix panic from FreeRTOS timer re-armed with a zero period

### DIFF
--- a/components/peripherals/src/led.c
+++ b/components/peripherals/src/led.c
@@ -62,39 +62,53 @@ static void timer_callback(TimerHandle_t xTimer)
     led->on = !led->on;
     gpio_set_level(led->gpio, led->on);
 
-    xTimerChangePeriod(xTimer, pdMS_TO_TICKS(led->on ? led->ontime : led->offtime), BLOCK_TIME);
+    // Guard against a zero period: led_set_state() may have switched this led to
+    // a solid state (ontime/offtime == 0) while this callback was already in
+    // flight. xTimerChangePeriod() with 0 ticks trips configASSERT() in the
+    // FreeRTOS timer task and panics, so don't re-arm in that case.
+    uint16_t next = led->on ? led->ontime : led->offtime;
+    if (next > 0) {
+        xTimerChangePeriod(xTimer, pdMS_TO_TICKS(next), BLOCK_TIME);
+    }
 }
 
 void led_set_state(led_id_t led_id, uint16_t ontime, uint16_t offtime)
 {
     struct led_s* led = &leds[led_id];
-    if (led->gpio != GPIO_NUM_NC) {
-        if (led->timer != NULL) {
-            xTimerStop(led->timer, BLOCK_TIME);
-            led->timer = NULL;
-        }
+    if (led->gpio == GPIO_NUM_NC) {
+        return;
+    }
 
-        led->ontime = ontime;
-        led->offtime = offtime;
+    // Keep one persistent timer per led and reuse it. Previously the timer was
+    // stopped and its handle dropped (leaking a timer on every reconfigure) and
+    // recreated each time, which under rapid reconfiguration left stopped-but-
+    // pending callbacks firing with stale on/off times.
+    if (led->timer != NULL) {
+        xTimerStop(led->timer, BLOCK_TIME);
+    }
 
-        if (ontime == 0) {
-            ESP_LOGD(TAG, "Set led %d off", led_id);
-            led->on = false;
-            gpio_set_level(led->gpio, led->on);
-        } else if (offtime == 0) {
-            ESP_LOGD(TAG, "Set led %d on", led_id);
-            led->on = true;
-            gpio_set_level(led->gpio, led->on);
+    led->ontime = ontime;
+    led->offtime = offtime;
+
+    if (ontime == 0) {
+        ESP_LOGD(TAG, "Set led %d off", led_id);
+        led->on = false;
+        gpio_set_level(led->gpio, led->on);
+    } else if (offtime == 0) {
+        ESP_LOGD(TAG, "Set led %d on", led_id);
+        led->on = true;
+        gpio_set_level(led->gpio, led->on);
+    } else {
+        ESP_LOGD(TAG, "Set led %d blink (on: %d off: %d)", led_id, ontime, offtime);
+
+        led->on = true;
+        gpio_set_level(led->gpio, led->on);
+
+        if (led->timer == NULL) {
+            led->timer = xTimerCreate("led_timer", pdMS_TO_TICKS(ontime), pdFALSE, (void*)led, timer_callback);
         } else {
-            ESP_LOGD(TAG, "Set led %d blink (on: %d off: %d)", led_id, ontime, offtime);
-
-            led->on = true;
-            gpio_set_level(led->gpio, led->on);
-
-            if (led->timer == NULL) {
-                led->timer = xTimerCreate("led_timer", pdMS_TO_TICKS(ontime), pdFALSE, (void*)led, timer_callback);
-            }
-            xTimerStart(led->timer, BLOCK_TIME);
+            xTimerChangePeriod(led->timer, pdMS_TO_TICKS(ontime), BLOCK_TIME);
         }
+        xTimerStart(led->timer, BLOCK_TIME);
     }
 }


### PR DESCRIPTION
## Problem

The controller intermittently panics and reboots. With a panic backtrace captured
across the reset, the crash symbolized to an assertion failure **inside the
FreeRTOS software-timer service task**, not in application code:

```
panic_abort                 panic.c
esp_system_abort
__assert_func               assert.c            <- a configASSERT() failed
prvProcessReceivedCommands  timers.c            <- in the Tmr Svc task
prvTimerTask                timers.c
vPortTaskWrapper
```

The failing assertion is `configASSERT( xTimerPeriodInTicks > 0 )` — a software
timer was started/changed with a period of **0 ticks**, which FreeRTOS forbids.

## Root cause

The status-LED driver (`components/peripherals/src/led.c`) is the source.

The blink `timer_callback()` re-arms the timer each tick with:

```c
xTimerChangePeriod(xTimer, pdMS_TO_TICKS(led->on ? led->ontime : led->offtime), BLOCK_TIME);
```

`led_set_state()` sets `ontime`/`offtime` to **0** when switching the LED to a
solid state (`led_set_on` → `(1, 0)`, `led_set_off` → `(0, 0)`). If a blink
callback is still in flight when the LED is reconfigured to solid, the callback
re-arms the timer with `pdMS_TO_TICKS(0) == 0` → the `configASSERT` above fires →
abort.

This is easy to hit whenever the LED is reconfigured rapidly. In our case a noisy
control-pilot line flapped the J1772 state `A ↔ B1` every ~50 ms process cycle,
and `update_leds()` reconfigured the CHARGING LED (blink ↔ solid) on every
transition — panicking within minutes, repeatedly.

A second, related defect: `led_set_state()` did `xTimerStop()` then
`led->timer = NULL` **without `xTimerDelete()`**, leaking one timer per
reconfigure and leaving a stopped-but-callback-may-be-pending timer behind.

## Fix

`components/peripherals/src/led.c`:

1. **Guard the re-arm** in `timer_callback()` — only call `xTimerChangePeriod()`
   when the next interval is `> 0`. This makes the path crash-proof regardless of
   reconfiguration timing.
2. **Reuse one persistent timer** per LED in `led_set_state()` (stop +
   `xTimerChangePeriod`) instead of orphaning the handle and recreating the timer
   each call. Fixes the leak and the stale-callback race.

No public API or behavior change for normal use; LEDs blink/solid exactly as
before.

## Testing

- Builds clean with ESP-IDF **v6.0.1** (`idf.py build`, ESP32 target).
- With the fix, the same rapid LED reconfiguration that previously aborted within
  minutes no longer panics; reset reason stays `Software`/`Power-on` instead of
  `Panic`.

## Notes

The control-pilot flapping that triggered this here is a separate, hardware-side
issue, but the firmware should never panic over LED reconfiguration regardless of
how the pilot behaves. A companion change debouncing the pilot reading is proposed
separately.


## Description:

**Related issue (if applicable):** fixes # (issue)

## Checklist:
- [x] The pull request is done against the latest master branch
- [x] The code change compiles without warnings
- [x] The code change are formatted (clang-format)
- [x] New and existing unit tests pass

Plase set Github secret _WOKWI_CLI_TOKEN_ to run CI unit test in Wokwi simulator  (https://docs.wokwi.com/wokwi-ci/github-actions)

_NOTE: The code change must pass CI. **Your PR cannot be merged unless CI pass**_
