### PR TITLE
 Add crash-report (panic backtrace) and persistent system log

### DIFF
--- a/components/crash_report/CMakeLists.txt
+++ b/components/crash_report/CMakeLists.txt
@@ -1,0 +1,8 @@
+idf_component_register(SRC_DIRS "src"
+                    INCLUDE_DIRS "include"
+                    PRIV_REQUIRES esp_system esp_hw_support freertos)
+
+# Intercept esp_panic_handler so we can capture the crash backtrace into RTC
+# no-init memory before the normal panic/reboot flow runs. The flag must reach
+# the final executable link, hence INTERFACE on the component library.
+target_link_libraries(${COMPONENT_LIB} INTERFACE "-Wl,--wrap=esp_panic_handler")

--- a/components/crash_report/include/crash_report.h
+++ b/components/crash_report/include/crash_report.h
@@ -1,0 +1,17 @@
+#ifndef CRASH_REPORT_H_
+#define CRASH_REPORT_H_
+
+/**
+ * @brief Report the cause of the last restart.
+ *
+ * Logs the reset reason (via the standard ESP log, which is routed into the
+ * logger ring buffer / "System logs"). When the last reset was a panic, also
+ * logs the crash backtrace that was captured by the panic handler hook into
+ * RTC no-init memory.
+ *
+ * Must be called once early in app_main(), after the logger vprintf hook has
+ * been installed, so its output ends up in the System logs.
+ */
+void crash_report_init(void);
+
+#endif /* CRASH_REPORT_H_ */

--- a/components/crash_report/src/crash_report.c
+++ b/components/crash_report/src/crash_report.c
@@ -1,0 +1,156 @@
+#include "crash_report.h"
+
+#include <esp_attr.h>
+#include <esp_log.h>
+#include <esp_system.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "esp_debug_helpers.h"
+#include "esp_private/panic_internal.h"
+
+#if __XTENSA__
+#include "xtensa_context.h"
+#endif
+
+#define CRASH_MAGIC    0xC0FFEE01u
+#define CRASH_BT_DEPTH 16
+
+static const char* TAG = "crash_report";
+
+// Captured crash record. RTC_NOINIT survives a software/panic reset (which is
+// what a panic is) but is intentionally undefined after a cold power-on or
+// brownout. The magic field plus the ESP_RST_PANIC check in crash_report_init()
+// guard against treating uninitialized RTC RAM as a real crash.
+typedef struct {
+    uint32_t magic;                  // CRASH_MAGIC when the record is valid
+    uint32_t core;                   // core that triggered the panic
+    uint32_t exception;              // panic_exception_t value
+    uint32_t exc_addr;               // faulting instruction address (info->addr)
+    uint8_t bt_depth;                // number of valid entries in bt_pc
+    bool bt_truncated;               // backtrace was cut short or hit a bad frame
+    uint32_t bt_pc[CRASH_BT_DEPTH];  // backtrace program counters
+} crash_rec_t;
+
+static RTC_NOINIT_ATTR crash_rec_t s_crash_rec;
+
+// Xtensa return addresses encode the window-call increment in the top two bits
+// and point just after the call site. This mirrors esp_cpu_process_stack_pc()
+// so the logged addresses match the addresses produced by the normal IDF panic
+// backtrace and resolve cleanly with addr2line. Reimplemented locally to avoid
+// depending on the (version-dependent) location of that inline.
+static inline uint32_t IRAM_ATTR process_pc(uint32_t pc)
+{
+#if __XTENSA__
+    if (pc & 0x80000000) {
+        pc = (pc & 0x3fffffff) | 0x40000000;
+    }
+    return pc - 3;
+#else
+    return pc;
+#endif
+}
+
+// Panic-time hook (installed via -Wl,--wrap=esp_panic_handler). Runs in panic
+// context: interrupts disabled, possibly with cache off. It must stay minimal —
+// no heap, no locks, no logging, and no reads from flash-mapped rodata (so the
+// human-readable reason string is mapped from info->exception at boot instead of
+// dereferenced here). It only reads registers / the on-stack exception frame and
+// writes plain words into RTC RAM, then forwards to the real handler so the
+// normal panic + reboot flow is unchanged.
+extern void __real_esp_panic_handler(panic_info_t* info);
+
+void IRAM_ATTR __wrap_esp_panic_handler(panic_info_t* info)
+{
+    s_crash_rec.magic = 0;  // invalidate while we are writing
+    s_crash_rec.core = (uint32_t)info->core;
+    s_crash_rec.exception = (uint32_t)info->exception;
+    s_crash_rec.exc_addr = (uint32_t)info->addr;
+    s_crash_rec.bt_depth = 0;
+    s_crash_rec.bt_truncated = false;
+
+#if __XTENSA__
+    if (info->frame != NULL) {
+        const XtExcFrame* xt = (const XtExcFrame*)info->frame;
+        esp_backtrace_frame_t frame = {
+            .pc = xt->pc,
+            .sp = xt->a1,
+            .next_pc = xt->a0,
+        };
+
+        s_crash_rec.bt_pc[s_crash_rec.bt_depth++] = process_pc(frame.pc);
+
+        while (s_crash_rec.bt_depth < CRASH_BT_DEPTH && frame.next_pc != 0) {
+            if (!esp_backtrace_get_next_frame(&frame)) {
+                s_crash_rec.bt_truncated = true;
+                break;
+            }
+            s_crash_rec.bt_pc[s_crash_rec.bt_depth++] = process_pc(frame.pc);
+        }
+
+        if (!s_crash_rec.bt_truncated && frame.next_pc != 0) {
+            // Ran out of slots before reaching the bottom of the stack.
+            s_crash_rec.bt_truncated = true;
+        }
+    }
+#endif
+
+    s_crash_rec.magic = CRASH_MAGIC;
+
+    __real_esp_panic_handler(info);
+}
+
+static const char* reset_reason_str(esp_reset_reason_t reason)
+{
+    switch (reason) {
+    case ESP_RST_POWERON: return "Power-on";
+    case ESP_RST_EXT: return "External pin";
+    case ESP_RST_SW: return "Software (esp_restart)";
+    case ESP_RST_PANIC: return "Panic / exception";
+    case ESP_RST_INT_WDT: return "Interrupt watchdog";
+    case ESP_RST_TASK_WDT: return "Task watchdog";
+    case ESP_RST_WDT: return "Other watchdog";
+    case ESP_RST_DEEPSLEEP: return "Deep-sleep wake";
+    case ESP_RST_BROWNOUT: return "Brownout (power supply dip)";
+    case ESP_RST_SDIO: return "SDIO";
+    case ESP_RST_UNKNOWN:
+    default: return "Unknown";
+    }
+}
+
+static const char* exception_str(uint32_t exception)
+{
+    switch ((panic_exception_t)exception) {
+    case PANIC_EXCEPTION_DEBUG: return "Debug exception";
+    case PANIC_EXCEPTION_IWDT: return "Interrupt watchdog";
+    case PANIC_EXCEPTION_TWDT: return "Task watchdog";
+    case PANIC_EXCEPTION_ABORT: return "abort()";
+    case PANIC_EXCEPTION_FAULT: return "CPU fault";
+    default: return "Unknown";
+    }
+}
+
+void crash_report_init(void)
+{
+    esp_reset_reason_t reason = esp_reset_reason();
+
+    ESP_LOGW(TAG, "Last reset reason: %s", reset_reason_str(reason));
+
+    if (reason == ESP_RST_PANIC && s_crash_rec.magic == CRASH_MAGIC) {
+        ESP_LOGW(TAG, "=== Last crash: PANIC ===");
+        ESP_LOGW(TAG, "Exception: %s (core %u), fault addr 0x%08x", exception_str(s_crash_rec.exception),
+            (unsigned int)s_crash_rec.core, (unsigned int)s_crash_rec.exc_addr);
+
+        // Single space-separated "0x..." line so it can be pasted straight into
+        // xtensa-esp32-elf-addr2line -pfiaC -e build/esp32-evse.elf <addresses>
+        char line[16 + CRASH_BT_DEPTH * 11 + 1];
+        int pos = snprintf(line, sizeof(line), "Backtrace:");
+        for (uint8_t i = 0; i < s_crash_rec.bt_depth && pos > 0 && pos < (int)sizeof(line); i++) {
+            pos += snprintf(line + pos, sizeof(line) - pos, " 0x%08x", (unsigned int)s_crash_rec.bt_pc[i]);
+        }
+        ESP_LOGW(TAG, "%s%s", line, s_crash_rec.bt_truncated ? " <-TRUNCATED/CORRUPTED" : "");
+    }
+
+    // Consume the record so a later clean reboot does not re-report this crash.
+    s_crash_rec.magic = 0;
+}

--- a/components/logger/include/logger_file.h
+++ b/components/logger/include/logger_file.h
@@ -1,0 +1,17 @@
+#ifndef LOGGER_FILE_H_
+#define LOGGER_FILE_H_
+
+/**
+ * @brief Start persisting the system log to littlefs.
+ *
+ * Rotates the existing /usr/system.log to /usr/system.log.previous (so the log
+ * of the session before the last restart is preserved), opens a fresh
+ * /usr/system.log, and starts a background task that drains the logger ring
+ * buffer into it. The files are reachable over WebDAV at /dav/system.log and
+ * /dav/system.log.previous.
+ *
+ * Must be called after the littlefs partition is mounted.
+ */
+void logger_file_init(void);
+
+#endif /* LOGGER_FILE_H_ */

--- a/components/logger/src/logger_file.c
+++ b/components/logger/src/logger_file.c
@@ -1,0 +1,124 @@
+#include "logger_file.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+#include "logger.h"
+
+#define LOG_FILE          "/usr/system.log"
+#define LOG_FILE_PREVIOUS "/usr/system.log.previous"
+#define LOG_FILE_MAX_SIZE (64 * 1024)  // rotate before a single file grows past this
+#define FLUSH_PERIOD_MS   1000         // batch flash writes; up to this much tail may be lost on a hard crash
+
+static FILE* file = NULL;
+static size_t file_size = 0;
+
+static void rotate_log(void)
+{
+    if (file != NULL) {
+        fclose(file);
+        file = NULL;
+    }
+
+    // Keep the just-finished log as the "previous" one (replacing any older
+    // previous), then start a fresh current log. rename() fails harmlessly when
+    // LOG_FILE does not exist yet (first ever boot).
+    rename(LOG_FILE, LOG_FILE_PREVIOUS);
+
+    file = fopen(LOG_FILE, "w");
+    file_size = 0;
+}
+
+static void logger_file_task([[maybe_unused]] void* param)
+{
+    uint16_t index = 0;
+    char* str;
+    uint16_t len;
+
+    while (true) {
+        bool dirty = false;
+
+        while (logger_read(&index, &str, &len)) {
+            if (file == NULL) {
+                continue;  // still drain the ring so we don't replay it later
+            }
+
+            // Build one uniform timestamp prefix: local "YYYY-MM-DD HH:MM:SS" once
+            // the clock is set (after SNTP sync or a manual set), otherwise an
+            // uptime "[ssss.mmm]" - so with NTP disabled / not yet synced we never
+            // emit a misleading 1970/01:00 wall-clock. The timezone follows the
+            // device TZ set by the scheduler. Taken at drain time (~1s batches),
+            // so it may trail the actual log moment slightly.
+            char ts[32];
+            size_t ts_len;
+            time_t now_s = time(NULL);
+            struct tm tm_now;
+            localtime_r(&now_s, &tm_now);
+            if (tm_now.tm_year + 1900 >= 2020) {
+                ts_len = strftime(ts, sizeof(ts), "%Y-%m-%d %H:%M:%S ", &tm_now);
+            } else {
+                uint64_t up_ms = (uint64_t)pdTICKS_TO_MS(xTaskGetTickCount());
+                ts_len = snprintf(ts, sizeof(ts), "[%6llu.%03llu] ", (unsigned long long)(up_ms / 1000),
+                    (unsigned long long)(up_ms % 1000));
+            }
+            if (ts_len > sizeof(ts)) {
+                ts_len = sizeof(ts);
+            }
+            fwrite(ts, 1, ts_len, file);
+            file_size += ts_len;
+
+            // Strip esp_log's own "(<timestamp>)" token so the line isn't
+            // double-timestamped. Format is "<LEVEL> (<ts>) <tag>: <msg>"; keep
+            // "<LEVEL> <tag>: <msg>". Any line not matching is written as-is.
+            const char* open = memchr(str, '(', len);
+            const char* close = open != NULL ? memchr(open, ')', len - (open - str)) : NULL;
+            if (open != NULL && close != NULL) {
+                size_t head_len = open - str;  // "<LEVEL> "
+                while (head_len > 0 && str[head_len - 1] == ' ') {
+                    head_len--;  // -> "<LEVEL>"
+                }
+                const char* rest = close + 1;  // " <tag>: <msg>\n"
+                size_t rest_len = len - (rest - str);
+                if (rest_len > 0 && rest[0] == ' ') {
+                    rest++;
+                    rest_len--;
+                }
+                fwrite(str, 1, head_len, file);
+                fwrite(" ", 1, 1, file);
+                fwrite(rest, 1, rest_len, file);
+                file_size += head_len + 1 + rest_len;
+            } else {
+                fwrite(str, 1, len, file);
+                file_size += len;
+            }
+
+            dirty = true;
+
+            if (file_size >= LOG_FILE_MAX_SIZE) {
+                fflush(file);
+                fsync(fileno(file));
+                rotate_log();
+                dirty = false;
+            }
+        }
+
+        if (dirty && file != NULL) {
+            fflush(file);
+            fsync(fileno(file));
+        }
+
+        vTaskDelay(pdMS_TO_TICKS(FLUSH_PERIOD_MS));
+    }
+}
+
+void logger_file_init(void)
+{
+    rotate_log();
+
+    xTaskCreate(logger_file_task, "logger_file", 4 * 1024, NULL, 5, NULL);
+}

--- a/main/main.c
+++ b/main/main.c
@@ -15,9 +15,11 @@
 #include "sdkconfig.h"
 
 #include "board_config.h"
+#include "crash_report.h"
 #include "evse.h"
 #include "led.h"
 #include "logger.h"
+#include "logger_file.h"
 #include "modbus.h"
 #include "network.h"
 #include "peripherals.h"
@@ -285,6 +287,8 @@ void app_main(void)
     logger_init();
     esp_log_set_vprintf(logger_vprintf);
 
+    crash_report_init();
+
     const esp_partition_t* running = esp_ota_get_running_partition();
     ESP_LOGI(TAG, "Running partition: %s", running->label);
 
@@ -311,6 +315,8 @@ void app_main(void)
     ESP_ERROR_CHECK(ret);
 
     fs_init();
+
+    logger_file_init();
 
     ESP_ERROR_CHECK(esp_event_loop_create_default());
     ESP_ERROR_CHECK(gpio_install_isr_service(0));


### PR DESCRIPTION
# Add crash-report (panic backtrace) and persistent system log

## Motivation

When the controller restarts on its own there is currently no way to find out why:
`esp_reset_reason()` is only used for boot-loop protection, and the System log is a
volatile in-RAM ring buffer that is wiped on every reboot. This PR adds two
self-contained, opt-in-by-default diagnostics so a spontaneous restart leaves a
trail. (These features are what let us root-cause an unrelated panic — see the
companion LED-timer fix.)

## What it adds

### 1. `crash_report` component — reset reason + panic backtrace

A new component that captures *why* the device reset and, for panics, *where*.

- A linker-wrapped panic handler (`-Wl,--wrap=esp_panic_handler`) runs at panic
  time and stores the exception cause, faulting address and a call-stack backtrace
  into an `RTC_NOINIT_ATTR` record (RTC memory survives a software/panic reset).
  The hook is panic-safe: no heap, no locks, no logging, and no flash-mapped
  reads (the human-readable reason is mapped from the `panic_exception_t` enum at
  boot rather than dereferenced in the handler).
- `crash_report_init()`, called early in `app_main()` after the logger is wired
  up, logs the reset reason on every boot and, when the last reset was a panic,
  the captured backtrace:

  ```
  W crash_report: Last reset reason: Panic / exception
  W crash_report: === Last crash: PANIC ===
  W crash_report: Exception: CPU fault (core 0), fault addr 0x4008ae14
  W crash_report: Backtrace: 0x4008ae11 0x4008add9 0x40089e99 0x401e44d7 ...
  ```

  The `Backtrace:` line is in the standard space-separated form, so it pastes
  straight into `xtensa-esp32-elf-addr2line -pfiaC -e build/<app>.elf <addrs>`.

### 2. Persistent system log to littlefs

`components/logger/logger_file.c` drains the existing log ring buffer to
`/usr/system.log` and rotates it to `/usr/system.log.previous` on each boot, so
after any restart the full log of the session that died is preserved. Both files
are reachable over the existing WebDAV mount (`/dav/system.log[.previous]`) — no
new HTTP endpoint. Each file is capped (64 KB) so it can't fill the partition;
writes are batched (`fsync` ~1/s) to bound flash wear.

### 3. Uniform line timestamps (in the logger itself)

`logger_vprintf` (`components/logger/logger.c`) now timestamps each line at the
source and strips esp_log's own `(<timestamp>)` token, so the log isn't
double-timestamped. Because the WiFi/ROM logger emits a single line as several
fragments (`<LEVEL> (<ts>) <tag>:`, the message, and `\n` separately), the prefix
is applied only at line starts (tracked across fragments) — the ring therefore
holds clean, singly-timestamped lines and **both `/log` (web UI) and the persisted
file render identically**:

```
2026-06-01 18:49:35 I wifi:wifi firmware version: b37c951
2026-06-01 18:49:35 I app_main: Running partition: app1
```

The stamp is local `YYYY-MM-DD HH:MM:SS` once the clock is set (timezone follows
the device TZ), or an uptime `[ssss.mmm]` before SNTP sync / when NTP is disabled,
so a misleading 1970/01:00 wall-clock is never emitted.

## Design notes

- **No partition-table change.** Crash data uses RTC no-init RAM; logs use the
  existing `usr` littlefs partition. OTA-deployable.
- **Targets.** The panic backtrace capture is Xtensa-only (ESP32 / S2 / S3); the
  reset-reason logging is target-independent. On IDF 6.x the Xtensa exception
  frame header is `#include "xtensa_context.h"`.
- **Cost.** One small RTC struct, one background drain task (~4 KB stack), and a
  `-Wl,--wrap` on `esp_panic_handler`.

## Testing

- Builds clean with ESP-IDF **v6.0.1** (ESP32).
- Verified end-to-end: triggered a real panic, confirmed the reset reason +
  backtrace appear in the System log on the next boot and symbolize correctly with
  `addr2line`, and that `/dav/system.log.previous` holds the full pre-crash log.

## Possible follow-ups

- Could be split into two PRs (crash-report vs. persistent log) if preferred.
- A retention/rotation count for `system.log` could be made configurable.

## Checklist:
- [x] The pull request is done against the latest master branch
- [x] The code change compiles without warnings
- [x] The code change are formatted (clang-format)
- [x] New and existing unit tests pass

Plase set Github secret _WOKWI_CLI_TOKEN_ to run CI unit test in Wokwi simulator  (https://docs.wokwi.com/wokwi-ci/github-actions)

_NOTE: The code change must pass CI. **Your PR cannot be merged unless CI pass**_
