### PR TITLE
debounce control-pilot voltage to ignore single-sample glitches

### DIFF
--- a/components/evse/src/evse.c
+++ b/components/evse/src/evse.c
@@ -27,6 +27,13 @@
 #define TEMP_THRESHOLD_MIN       40
 #define TEMP_THRESHOLD_MAX       80
 
+// Number of consecutive evse_process() samples a new pilot voltage must hold
+// before the state machine acts on it. Debounces a noisy CP line (which can
+// otherwise flap A<->B1 with no cable connected). At the ~50ms process cadence
+// this is roughly PILOT_STABLE_SAMPLES*50ms of added latency on state changes
+// (including disconnect detection during charging); lower to 2 if faster.
+#define PILOT_STABLE_SAMPLES 3
+
 #define NVS_NAMESPACE                   "evse"
 #define NVS_MAX_CHARGING_CURRENT        "max_chrg_curr"
 #define NVS_DEFAULT_CHARGING_CURRENT    "def_chrg_curr"
@@ -317,6 +324,32 @@ void evse_process(void)
     pilot_voltage_t pilot_voltage;
     bool pilot_down_voltage_n12;
     pilot_measure(&pilot_voltage, &pilot_down_voltage_n12);
+
+    // Debounce the pilot voltage so a single noisy sample can't flap the state
+    // machine (A<->B1 with no cable), which would hammer the relay / energy
+    // meter / LED. A changed reading must persist PILOT_STABLE_SAMPLES times in
+    // a row before the state machine below sees it. (pilot_down_voltage_n12,
+    // used for the diode-short check, is intentionally left on the raw reading.)
+    {
+        static pilot_voltage_t stable_voltage = PILOT_VOLTAGE_12;
+        static pilot_voltage_t prev_raw = PILOT_VOLTAGE_12;
+        static uint8_t stable_count = 0;
+
+        if (pilot_voltage == prev_raw) {
+            if (stable_count < PILOT_STABLE_SAMPLES) {
+                stable_count++;
+            }
+        } else {
+            prev_raw = pilot_voltage;
+            stable_count = 1;
+        }
+
+        if (stable_count >= PILOT_STABLE_SAMPLES) {
+            stable_voltage = pilot_voltage;
+        }
+
+        pilot_voltage = stable_voltage;
+    }
 
     if (is_expired(&error_wait_to)) {
         clear_error_bits(EVSE_ERR_AUTO_CLEAR_BITS);


### PR DESCRIPTION
# evse: debounce control-pilot voltage to ignore single-sample glitches

## Problem

`evse_process()` reads the control-pilot voltage once per loop (~50 ms) and acts
on it immediately. On a noisy CP line a single spurious sample is enough to drive
a state transition, so the state machine can flap — e.g. `A ↔ B1` every cycle with
**no cable connected** — repeatedly switching the AC relay, starting/stopping
energy-meter sessions and reconfiguring the status LED:

```
evse: Enter B1 state
ac_relay: Set relay: 0
energy_meter: Start session
evse: Enter A state
ac_relay: Set relay: 0
energy_meter: Stop session
... (repeats every few hundred ms)
```

Besides the relay/meter/LED churn, this is what exposed the LED-timer panic fixed
in the companion PR.

## Fix

Debounce the pilot voltage in `evse_process()`: a *changed* reading must hold for
`PILOT_STABLE_SAMPLES` consecutive samples before the state machine acts on it.
A single-sample glitch is rejected; a genuine transition is accepted after
`PILOT_STABLE_SAMPLES` reads. The diode-short check, which uses the separate
`pilot_down_voltage_n12` flag, is intentionally left on the raw reading.

`PILOT_STABLE_SAMPLES` defaults to `3` (~150 ms at the current process cadence).

## Trade-off

This adds roughly `PILOT_STABLE_SAMPLES × loop_period` of latency to legitimate
state changes, **including disconnect detection while charging**. At the default
(~150 ms) that's fine for typical use and well-behaved; set it to `2` (~100 ms) if
you want faster reaction, or tune to taste. It's a single `#define`.

## Testing

- Builds clean with ESP-IDF **v6.0.1** (ESP32).
- With the debounce, a noisy/floating CP line no longer flaps the state machine;
  the relay/meter/LED churn above disappears.

## Notes

The root noise is hardware-side (CP front-end), but the firmware shouldn't thrash
on a single bad sample. This pairs naturally with the LED-timer crash fix; happy
to squash them into one "robustness on a noisy pilot" PR if preferred.


## Checklist:
- [x] The pull request is done against the latest master branch
- [x] The code change compiles without warnings
- [x] The code change are formatted (clang-format)
- [x] New and existing unit tests pass

Plase set Github secret _WOKWI_CLI_TOKEN_ to run CI unit test in Wokwi simulator  (https://docs.wokwi.com/wokwi-ci/github-actions)

_NOTE: The code change must pass CI. **Your PR cannot be merged unless CI pass**_
