### PR TITLE
http: enable lru_purge so a full socket pool can't lock out the UI

### DIFF
--- a/components/protocols/src/http.c
+++ b/components/protocols/src/http.c
@@ -113,8 +113,12 @@ void http_init(void)
     config.stack_size = 5 * 1024;  // default 4096 not enought for OTA esp_https_ota
     config.uri_match_fn = httpd_uri_match_wildcard;
     config.max_uri_handlers = http_rest_handlers_count() + http_dav_handlers_count() + http_web_handlers_count();
+    // Close the least-recently-used connection when the socket pool is full so a
+    // new client can always get in. Without this, lingering/keep-alive
+    // connections eventually fill all max_open_sockets slots and the server stops
+    // accepting (UI unreachable while ping still works) until the link is reset.
+    config.lru_purge_enable = true;
     // config.max_open_sockets = 3;
-    // config.lru_purge_enable = true;
     // config.open_fn = sess_on_open;
     // config.close_fn = sess_on_close;
 


### PR DESCRIPTION
# http: enable lru_purge so a full socket pool can't lock out the UI

## Problem

After long uptime the web UI becomes unreachable: the device still answers ping,
but TCP connections to port 80 time out (no SYN-ACK, no RST). It only recovers
when the WiFi link is reset (e.g. AP reboot), which tears down all the device's
TCP connections.

The HTTP server runs with the default `max_open_sockets` (7) and
`lru_purge_enable = false`. Lingering/keep-alive client connections (a left-open
browser tab polling `/log` and friends, a monitoring client, half-open peers that
went away without closing) gradually occupy all socket slots. Once the pool is
full, `httpd` stops accepting new connections entirely — ping keeps working
(ICMP is independent of the socket pool) but the UI is dead until the slots are
freed by a link reset.

Captured server logs at the moment of the link reset show the accept path was the
bottleneck:

```
httpd_txrx: httpd_sock_err: error in recv : 113
httpd: httpd_accept_conn: error in accept (128)
httpd: httpd_server: error accepting new connection
```

## Fix

Enable `config.lru_purge_enable` in `http_init()`
(`components/protocols/src/http.c`). When the socket pool is full and a new
connection arrives, the server closes the least-recently-used socket to make
room, so a fresh client (browser, curl) can always get in. The UI can no longer
be permanently locked out by stale connections.

```c
config.lru_purge_enable = true;
```

(The option was already present in the file, commented out.)

## Testing

- Builds clean with ESP-IDF **v6.0.1** (ESP32).
- With LRU purge enabled, a new request always evicts the oldest connection and
  succeeds, so the "ping works but :80 is dead" lockout no longer occurs.

## Possible follow-ups (not in this PR)

- **TCP keepalive** (`config.keep_alive_enable` + idle/interval/count) to
  proactively reap dead/half-open peers on a timer, complementing the on-demand
  LRU purge.
- **Raise `max_open_sockets`** (default 7; up to ~`LWIP_MAX_SOCKETS - 3` = 13 with
  the current lwip config) for more concurrent connections and less purge churn,
  if socket budget allows alongside the other services.

## Description:

**Related issue (if applicable):** fixes # (issue)

## Checklist:
- [x] The pull request is done against the latest master branch
- [x] The code change compiles without warnings
- [x] The code change are formatted (clang-format)
- [x] New and existing unit tests pass

Plase set Github secret _WOKWI_CLI_TOKEN_ to run CI unit test in Wokwi simulator  (https://docs.wokwi.com/wokwi-ci/github-actions)

_NOTE: The code change must pass CI. **Your PR cannot be merged unless CI pass**_
