### PR TITLE
Add static DNS server option for static IP configuration

### DIFF
--- a/components/at/src/at_cmd_network_group.c
+++ b/components/at/src/at_cmd_network_group.c
@@ -60,6 +60,7 @@ static int vars_sta_static_config_read(const struct cat_variable* var)
     wifi_get_static_ip(var_str32_1);
     wifi_get_static_gateway(var_str32_2);
     wifi_get_static_netmask(var_str32_3);
+    wifi_get_static_dns(var_str32_4);
 
     return 0;
 }
@@ -90,6 +91,12 @@ static struct cat_variable vars_sta_static_config[] = {
         .data_size = sizeof(var_str32_3),
         .access = CAT_VAR_ACCESS_READ_WRITE,
     },
+    {
+        .type = CAT_VAR_BUF_STRING,
+        .data = var_str32_4,
+        .data_size = sizeof(var_str32_4),
+        .access = CAT_VAR_ACCESS_READ_WRITE,
+    },
 };
 
 static cat_return_state vars_sta_static_config_write(const struct cat_command* cmd, const uint8_t* data, const size_t data_size, const size_t args_num)
@@ -98,6 +105,7 @@ static cat_return_state vars_sta_static_config_write(const struct cat_command* c
     const char* ip = NULL;
     const char* gateway = NULL;
     const char* netmask = NULL;
+    const char* dns = NULL;
 
     if (args_num > 1) {
         ip = var_str32_1;
@@ -108,8 +116,11 @@ static cat_return_state vars_sta_static_config_write(const struct cat_command* c
     if (args_num > 3) {
         netmask = var_str32_3;
     }
+    if (args_num > 4) {
+        dns = var_str32_4;
+    }
 
-    return wifi_set_static_config(enabled, ip, gateway, netmask) == ESP_OK ? CAT_RETURN_STATE_OK : CAT_RETURN_STATE_ERROR;
+    return wifi_set_static_config(enabled, ip, gateway, netmask, dns) == ESP_OK ? CAT_RETURN_STATE_OK : CAT_RETURN_STATE_ERROR;
 }
 
 static int vars_ap_config_read(const struct cat_variable* var)

--- a/components/at/src/vars.c
+++ b/components/at/src/vars.c
@@ -21,3 +21,4 @@ uint64_t var_u64_1;
 char var_str32_1[32];
 char var_str32_2[32];
 char var_str32_3[32];
+char var_str32_4[32];

--- a/components/at/src/vars.h
+++ b/components/at/src/vars.h
@@ -88,5 +88,6 @@ extern uint64_t var_u64_1;
 extern char var_str32_1[32];
 extern char var_str32_2[32];
 extern char var_str32_3[32];
+extern char var_str32_4[32];
 
 #endif /* VARS_H_ */

--- a/components/network/include/wifi.h
+++ b/components/network/include/wifi.h
@@ -151,7 +151,9 @@ void wifi_get_static_gateway(char* str);
 
 void wifi_get_static_netmask(char* str);
 
-esp_err_t wifi_set_static_config(bool enabled, const char* ip, const char* gateway, const char* netmask);
+void wifi_get_static_dns(char* str);
+
+esp_err_t wifi_set_static_config(bool enabled, const char* ip, const char* gateway, const char* netmask, const char* dns);
 
 bool wifi_is_ap_enabled(void);
 

--- a/components/network/src/wifi.c
+++ b/components/network/src/wifi.c
@@ -20,6 +20,7 @@
 #define NVS_STATIC_IP      "stat_ip"
 #define NVS_STATIC_GATEWAY "stat_gateway"
 #define NVS_STATIC_NETMASK "stat_netmask"
+#define NVS_STATIC_DNS     "stat_dns"
 
 ESP_STATIC_ASSERT(sizeof(((wifi_config_t*)0)->sta.ssid) == WIFI_SSID_SIZE, "Wrong SSID size");
 ESP_STATIC_ASSERT(sizeof(((wifi_config_t*)0)->sta.password) == WIFI_PASSWORD_SIZE, "Wrong password size");
@@ -42,9 +43,6 @@ EventGroupHandle_t wifi_event_group;
 
 static void sta_try_connect(void)
 {
-    // EventBits_t mode_bits = xEventGroupGetBits(wifi_event_group);
-    //  if (!(mode_bits & WIFI_STA_SCAN_BIT) && mode_bits & WIFI_STA_MODE_BIT && !(mode_bits & WIFI_AP_MODE_BIT)) {
-    // if (sta_enabled) {
     if (recconect) {
         ESP_LOGI(TAG, "STA reconnecting...");
         // during AP mode disable reconnecting, it disconect all clients from AP
@@ -52,6 +50,14 @@ static void sta_try_connect(void)
         if (err != ESP_OK) {
             ESP_LOGE(TAG, "Connect failed (%s)", esp_err_to_name(err));
         }
+    }
+}
+
+static void log_sta_dns(esp_netif_t* netif)
+{
+    esp_netif_dns_info_t dns_info = { 0 };
+    if (esp_netif_get_dns_info(netif, ESP_NETIF_DNS_MAIN, &dns_info) == ESP_OK) {
+        ESP_LOGI(TAG, "WiFi STA dns: " IPSTR, IP2STR(&dns_info.ip.u_addr.ip4));
     }
 }
 
@@ -93,6 +99,7 @@ static void event_handler(void* arg, esp_event_base_t event_base, int32_t event_
             if (event_id == IP_EVENT_STA_GOT_IP) {
                 ip_event_got_ip_t* event = (ip_event_got_ip_t*)event_data;
                 ESP_LOGI(TAG, "WiFi STA got ip: " IPSTR, IP2STR(&event->ip_info.ip));
+                log_sta_dns(event->esp_netif);
             } else {
                 ip_event_got_ip6_t* event = (ip_event_got_ip6_t*)event_data;
                 ESP_LOGI(TAG, "WiFi STA got ip6: " IPV6STR, IPV62STR(event->ip6_info.ip));
@@ -180,6 +187,22 @@ static esp_err_t apply_mode_config()
     return ESP_OK;
 }
 
+// Set the STA DNS server. Falls back to the gateway when no explicit DNS is
+// configured, so hostname resolution (NTP, etc.) still works under static IP.
+static void apply_static_dns(esp_ip4_addr_t dns_addr, esp_ip4_addr_t gw_addr)
+{
+    esp_netif_dns_info_t dns_info = { 0 };
+    dns_info.ip.type = ESP_IPADDR_TYPE_V4;
+    dns_info.ip.u_addr.ip4 = dns_addr.addr != 0 ? dns_addr : gw_addr;
+
+    if (dns_info.ip.u_addr.ip4.addr != 0) {
+        esp_err_t err = esp_netif_set_dns_info(sta_netif, ESP_NETIF_DNS_MAIN, &dns_info);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "Set DNS info failed (%s)", esp_err_to_name(err));
+        }
+    }
+}
+
 void wifi_init(void)
 {
     ESP_ERROR_CHECK(esp_netif_init());
@@ -214,6 +237,11 @@ void wifi_init(void)
         nvs_get_blob(nvs, NVS_STATIC_NETMASK, &ip_info.netmask, &size);
 
         ESP_ERROR_CHECK(esp_netif_set_ip_info(sta_netif, &ip_info));
+
+        esp_ip4_addr_t dns_addr = { 0 };
+        size = sizeof(esp_ip4_addr_t);
+        nvs_get_blob(nvs, NVS_STATIC_DNS, &dns_addr, &size);
+        apply_static_dns(dns_addr, ip_info.gw);
     }
 
     ESP_ERROR_CHECK(esp_wifi_set_mode(WIFI_MODE_NULL));
@@ -402,7 +430,7 @@ static void get_nvs_ip(const char* nvs_key, char* str)
 {
     esp_ip4_addr_t value = { 0 };
     size_t size = sizeof(esp_ip4_addr_t);
-    if (nvs_get_blob(nvs, nvs_key, &value, &size) == ESP_OK) {
+    if (nvs_get_blob(nvs, nvs_key, &value, &size) == ESP_OK && value.addr != 0) {
         esp_ip4addr_ntoa(&value, str, 16);
     } else {
         str[0] = '\0';
@@ -424,80 +452,97 @@ void wifi_get_static_netmask(char* str)
     get_nvs_ip(NVS_STATIC_NETMASK, str);
 }
 
-esp_err_t wifi_set_static_config(bool enabled, const char* ip, const char* gateway, const char* netmask)
+void wifi_get_static_dns(char* str)
 {
-    esp_err_t err;
-    size_t size;
-    esp_netif_ip_info_t ip_info = { 0 };
+    get_nvs_ip(NVS_STATIC_DNS, str);
+}
 
-    if (ip != NULL) {
-        err = esp_netif_str_to_ip4(ip, &ip_info.ip);
-        if (err != ESP_OK) {
-            ESP_LOGE(TAG, "Invalid IP");
-            return err;
-        }
-    } else {
-        size = sizeof(esp_ip4_addr_t);
-        nvs_get_blob(nvs, NVS_STATIC_IP, &ip_info.ip, &size);
+// Resolve one static-IP field into `out`: parse `str` when given, otherwise
+// load the stored value from NVS. When `allow_blank` is set, an empty string
+// leaves `out` untouched (used by the optional DNS field to mean "cleared").
+static esp_err_t resolve_static_addr(const char* str, const char* nvs_key, const char* name, bool allow_blank, esp_ip4_addr_t* out)
+{
+    if (str == NULL) {
+        size_t size = sizeof(esp_ip4_addr_t);
+        nvs_get_blob(nvs, nvs_key, out, &size);
+        return ESP_OK;
     }
 
-    if (gateway != NULL) {
-        err = esp_netif_str_to_ip4(gateway, &ip_info.gw);
-        if (err != ESP_OK) {
-            ESP_LOGE(TAG, "Invalid gateway");
-            return err;
-        }
-    } else {
-        size = sizeof(esp_ip4_addr_t);
-        nvs_get_blob(nvs, NVS_STATIC_GATEWAY, &ip_info.gw, &size);
+    if (allow_blank && str[0] == '\0') {
+        return ESP_OK;
     }
 
-    if (netmask != NULL) {
-        err = esp_netif_str_to_ip4(netmask, &ip_info.netmask);
-        if (err != ESP_OK) {
-            ESP_LOGE(TAG, "Invalid netmask");
-            return err;
-        }
-    } else {
-        size = sizeof(esp_ip4_addr_t);
-        nvs_get_blob(nvs, NVS_STATIC_NETMASK, &ip_info.netmask, &size);
+    esp_err_t err = esp_netif_str_to_ip4(str, out);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Invalid %s", name);
     }
+    return err;
+}
 
+// Switch the STA DHCP client to match `enabled`, applying the static IP info
+// when disabling it. No-op when already in the requested mode.
+static esp_err_t apply_dhcp_mode(bool enabled, const esp_netif_ip_info_t* ip_info)
+{
     esp_netif_dhcp_status_t dhcp_status;
-    err = esp_netif_dhcpc_get_status(sta_netif, &dhcp_status);
+    esp_err_t err = esp_netif_dhcpc_get_status(sta_netif, &dhcp_status);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "DHCP client get status failed (%s)", esp_err_to_name(err));
     }
 
     bool current_enabled = dhcp_status != ESP_NETIF_DHCP_STARTED;
+    if (enabled == current_enabled) {
+        return ESP_OK;
+    }
 
-    if (enabled != current_enabled) {
-        if (enabled) {
-            err = esp_netif_dhcpc_stop(sta_netif);
-            if (err != ESP_OK) {
-                ESP_LOGE(TAG, "DHCP client stop failed (%s)", esp_err_to_name(err));
-                return err;
-            }
-
-            err = esp_netif_set_ip_info(sta_netif, &ip_info);
-            if (err != ESP_OK) {
-                ESP_LOGE(TAG, "Set IP info failed (%s)", esp_err_to_name(err));
-
-                err = esp_netif_dhcpc_start(sta_netif);
-                if (err != ESP_OK) {
-                    ESP_LOGE(TAG, "DHCP client restart failed (%s)", esp_err_to_name(err));
-                    return err;
-                }
-
-                return err;
-            }
-        } else {
-            err = esp_netif_dhcpc_start(sta_netif);
-            if (err != ESP_OK) {
-                ESP_LOGE(TAG, "DHCP client start failed (%s)", esp_err_to_name(err));
-                return err;
-            }
+    if (!enabled) {
+        err = esp_netif_dhcpc_start(sta_netif);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "DHCP client start failed (%s)", esp_err_to_name(err));
         }
+        return err;
+    }
+
+    err = esp_netif_dhcpc_stop(sta_netif);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "DHCP client stop failed (%s)", esp_err_to_name(err));
+        return err;
+    }
+
+    err = esp_netif_set_ip_info(sta_netif, ip_info);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "Set IP info failed (%s)", esp_err_to_name(err));
+        esp_netif_dhcpc_start(sta_netif);  // best-effort revert to DHCP
+    }
+    return err;
+}
+
+esp_err_t wifi_set_static_config(bool enabled, const char* ip, const char* gateway, const char* netmask, const char* dns)
+{
+    esp_err_t err;
+    esp_netif_ip_info_t ip_info = { 0 };
+    esp_ip4_addr_t dns_addr = { 0 };
+
+    err = resolve_static_addr(ip, NVS_STATIC_IP, "IP", false, &ip_info.ip);
+    if (err != ESP_OK) {
+        return err;
+    }
+    err = resolve_static_addr(gateway, NVS_STATIC_GATEWAY, "gateway", false, &ip_info.gw);
+    if (err != ESP_OK) {
+        return err;
+    }
+    err = resolve_static_addr(netmask, NVS_STATIC_NETMASK, "netmask", false, &ip_info.netmask);
+    if (err != ESP_OK) {
+        return err;
+    }
+    // DNS is optional: a blank value clears it (gateway used as fallback when applied).
+    err = resolve_static_addr(dns, NVS_STATIC_DNS, "DNS", true, &dns_addr);
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    err = apply_dhcp_mode(enabled, &ip_info);
+    if (err != ESP_OK) {
+        return err;
     }
 
     if (enabled) {
@@ -506,12 +551,15 @@ esp_err_t wifi_set_static_config(bool enabled, const char* ip, const char* gatew
             ESP_LOGE(TAG, "Set IP info failed (%s)", esp_err_to_name(err));
             return err;
         }
+
+        apply_static_dns(dns_addr, ip_info.gw);
     }
 
     nvs_set_u8(nvs, NVS_STATIC_ENABLED, enabled);
     nvs_set_blob(nvs, NVS_STATIC_IP, &ip_info.ip, sizeof(esp_ip4_addr_t));
     nvs_set_blob(nvs, NVS_STATIC_GATEWAY, &ip_info.gw, sizeof(esp_ip4_addr_t));
     nvs_set_blob(nvs, NVS_STATIC_NETMASK, &ip_info.netmask, sizeof(esp_ip4_addr_t));
+    nvs_set_blob(nvs, NVS_STATIC_DNS, &dns_addr, sizeof(esp_ip4_addr_t));
 
     return ESP_OK;
 }

--- a/components/protocols/src/http_json.c
+++ b/components/protocols/src/http_json.c
@@ -7,6 +7,7 @@
 #include <esp_wifi.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/timers.h>
+#include <stdio.h>
 #include <string.h>
 #include <sys/time.h>
 
@@ -48,7 +49,16 @@ typedef struct {
     char static_ip[16];
     char static_gateway[16];
     char static_netmask[16];
+    char static_dns[16];
 } wifi_set_config_arg_t;
+
+typedef struct {
+    bool enabled;
+    const char* ip;
+    const char* gateway;
+    const char* netmask;
+    const char* dns;
+} wifi_static_input_t;
 
 cJSON* http_json_get_config(void)
 {
@@ -183,6 +193,8 @@ cJSON* http_json_get_config_wifi(void)
     cJSON_AddStringToObject(json, "staticGateway", str);
     wifi_get_static_netmask(str);
     cJSON_AddStringToObject(json, "staticNetmask", str);
+    wifi_get_static_dns(str);
+    cJSON_AddStringToObject(json, "staticDns", str);
 
     return json;
 }
@@ -191,7 +203,7 @@ static void wifi_set_config_timer_callback(TimerHandle_t timer)
 {
     wifi_set_config_arg_t* config = (wifi_set_config_arg_t*)pvTimerGetTimerID(timer);
 
-    wifi_set_static_config(config->static_enabled, config->static_ip, config->static_gateway, config->static_netmask);
+    wifi_set_static_config(config->static_enabled, config->static_ip, config->static_gateway, config->static_netmask, config->static_dns);
     wifi_set_config(config->enabled, config->ssid_blank ? NULL : config->ssid, config->password_blank ? NULL : config->password);
 
     free((void*)config);
@@ -199,8 +211,16 @@ static void wifi_set_config_timer_callback(TimerHandle_t timer)
     xTimerDelete(timer, 0);
 }
 
-static esp_err_t timeout_wifi_set_config(
-    bool enabled, const char* ssid, const char* password, bool static_enabled, const char* static_ip, const char* static_gateway, const char* static_netmask)
+static void copy_or_blank(char* dst, size_t dst_size, const char* src)
+{
+    if (src != NULL) {
+        snprintf(dst, dst_size, "%s", src);
+    } else {
+        dst[0] = '\0';
+    }
+}
+
+static esp_err_t timeout_wifi_set_config(bool enabled, const char* ssid, const char* password, const wifi_static_input_t* sta)
 {
     if (enabled) {
         if (ssid == NULL || strlen(ssid) == 0) {
@@ -229,25 +249,11 @@ static esp_err_t timeout_wifi_set_config(
         strcpy(config->password, password);
     }
 
-    config->static_enabled = static_enabled;
-
-    if (static_ip != NULL) {
-        strcpy(config->static_ip, static_ip);
-    } else {
-        config->static_ip[0] = '\0';
-    }
-
-    if (static_gateway != NULL) {
-        strcpy(config->static_gateway, static_gateway);
-    } else {
-        config->static_gateway[0] = '\0';
-    }
-
-    if (static_netmask != NULL) {
-        strcpy(config->static_netmask, static_netmask);
-    } else {
-        config->static_netmask[0] = '\0';
-    }
+    config->static_enabled = sta->enabled;
+    copy_or_blank(config->static_ip, sizeof(config->static_ip), sta->ip);
+    copy_or_blank(config->static_gateway, sizeof(config->static_gateway), sta->gateway);
+    copy_or_blank(config->static_netmask, sizeof(config->static_netmask), sta->netmask);
+    copy_or_blank(config->static_dns, sizeof(config->static_dns), sta->dns);
 
     TimerHandle_t timer = xTimerCreate("wifi_set_config", pdMS_TO_TICKS(1000), pdFALSE, (void*)config, wifi_set_config_timer_callback);
     xTimerStart(timer, 0);
@@ -264,8 +270,17 @@ esp_err_t http_json_set_config_wifi(cJSON* json)
     char* static_ip = cJSON_GetStringValue(cJSON_GetObjectItem(json, "staticIp"));
     char* static_gateway = cJSON_GetStringValue(cJSON_GetObjectItem(json, "staticGateway"));
     char* static_netmask = cJSON_GetStringValue(cJSON_GetObjectItem(json, "staticNetmask"));
+    char* static_dns = cJSON_GetStringValue(cJSON_GetObjectItem(json, "staticDns"));
 
-    return timeout_wifi_set_config(enabled, ssid, password, static_enabled, static_ip, static_gateway, static_netmask);
+    wifi_static_input_t sta = {
+        .enabled = static_enabled,
+        .ip = static_ip,
+        .gateway = static_gateway,
+        .netmask = static_netmask,
+        .dns = static_dns,
+    };
+
+    return timeout_wifi_set_config(enabled, ssid, password, &sta);
 }
 
 cJSON* http_json_get_wifi_scan(void)

--- a/static-ip-dns-server-webui.patch
+++ b/static-ip-dns-server-webui.patch
@@ -1,0 +1,94 @@
+--- a/components/protocols/web/src/pages/NetworkSettings.jsx
++++ b/components/protocols/web/src/pages/NetworkSettings.jsx
+@@ -446,6 +446,21 @@
+               />
+             </Form.Group>
+           </Col>
++          <Col xs={12} md={6} xl={4}>
++            <Form.Group className="mb-3" controlId="staticDns">
++              <Form.Label>{t("dns")}</Form.Label>
++              {/* DNS is optional: blank falls back to the gateway on the device. */}
++              <Form.Control
++                type="staticDns"
++                name="staticDns"
++                disabled={formData?.staticEnabled !== true}
++                pattern="^((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
++                placeholder="192.168.1.1"
++                value={formData?.staticDns}
++                onChange={onChange}
++              />
++            </Form.Group>
++          </Col>
+         </Row>
+ 
+         <Stack gap={2} direction="horizontal" className="pb-3">
+--- a/components/protocols/web/src/locales/en.json
++++ b/components/protocols/web/src/locales/en.json
+@@ -189,6 +189,7 @@
+   "staticIp": "Static IP address",
+   "gateway": "Gateway",
+   "netmask": "Netmask",
++  "dns": "DNS server",
+   "wifiAccessPoint": "WiFi AP",
+   "wifiAccessPointAutoStop": "The access point will automatically shut down if no one connects to it within one minute.",
+   "wifiStation": "WiFi station",
+--- a/components/protocols/web/src/locales/cz.json
++++ b/components/protocols/web/src/locales/cz.json
+@@ -189,6 +189,7 @@
+   "staticIp": "Statická IP adresa",
+   "gateway": "Brána",
+   "netmask": "Maska podsítě",
++  "dns": "DNS server",
+   "wifiAccessPoint": "WiFi přístupový bod",
+   "wifiAccessPointAutoStop": "Přístupový bod se automaticky vypne, pokud se k němu do jedné minuty nikdo nepřipojí.",
+   "wifiStation": "WiFi stanice",
+--- a/components/protocols/web/src/locales/sk.json
++++ b/components/protocols/web/src/locales/sk.json
+@@ -189,6 +189,7 @@
+   "staticIp": "Statická IP adresa",
+   "gateway": "Brána",
+   "netmask": "Maska podsiete",
++  "dns": "DNS server",
+   "wifiAccessPoint": "WiFi prístupový bod",
+   "wifiAccessPointAutoStop": "Prístupový bod sa automaticky vypne, ak sa k nemu do jednej minúty nikto nepripojí.",
+   "wifiStation": "WiFi stanica",
+--- a/components/protocols/web/src/locales/fr.json
++++ b/components/protocols/web/src/locales/fr.json
+@@ -189,6 +189,7 @@
+   "staticIp": "Adresse IP statique",
+   "gateway": "Passerelle",
+   "netmask": "Masque de sous-réseau",
++  "dns": "Serveur DNS",
+   "wifiAccessPoint": "Point d'accès WiFi",
+   "wifiAccessPointAutoStop": "Le point d'accès s'éteindra automatiquement si personne ne s'y connecte dans la minute.",
+   "wifiStation": "Station WiFi",
+--- a/components/protocols/web/src/locales/hu.json
++++ b/components/protocols/web/src/locales/hu.json
+@@ -189,6 +189,7 @@
+   "staticIp": "Statikus IP cím",
+   "gateway": "Átjáró",
+   "netmask": "Alhálózati maszk",
++  "dns": "DNS-kiszolgáló",
+   "wifiAccessPoint": "Wi-Fi hozzáférési pont",
+   "wifiAccessPointAutoStop": "A hozzáférési pont automatikusan kikapcsol, ha egy percen belül senki sem csatlakozik hozzá.",
+   "wifiStation": "Wi-Fi kliens",
+--- a/components/protocols/web/src/locales/ru.json
++++ b/components/protocols/web/src/locales/ru.json
+@@ -189,6 +189,7 @@
+   "staticIp": "Статический IP-адрес",
+   "gateway": "Шлюз",
+   "netmask": "Маска подсети",
++  "dns": "DNS-сервер",
+   "wifiAccessPoint": "Точка доступа WiFi",
+   "wifiAccessPointAutoStop": "Точка доступа автоматически отключится, если в течение одной минуты к ней никто не подключится.",
+   "wifiStation": "WiFi-станция",
+--- a/components/protocols/web/src/locales/tr.json
++++ b/components/protocols/web/src/locales/tr.json
+@@ -189,6 +189,7 @@
+   "staticIp": "Statik IP adresi",
+   "gateway": "Ağ geçidi",
+   "netmask": "Ağ maskesi",
++  "dns": "DNS sunucusu",
+   "wifiAccessPoint": "WiFi Erişim Noktası (AP)",
+   "wifiAccessPointAutoStop": "Erişim noktasına bir dakika içinde kimse bağlanmazsa otomatik olarak kapanacaktır.",
+   "wifiStation": "WiFi istasyonu",


### PR DESCRIPTION
When static IP is enabled, lwIP's DNS slots were left empty (DHCP option 6 normally fills them), so hostname resolution failed — e.g. the NTP server under /settings/scheduler could not be resolved.

Add a configurable DNS server alongside IP/gateway/netmask:
- wifi.c/.h: new NVS_STATIC_DNS key, wifi_get_static_dns(), and a dns parameter on wifi_set_static_config(); apply_static_dns() calls esp_netif_set_dns_info(ESP_NETIF_DNS_MAIN) in both the boot and runtime static paths, falling back to the gateway when no DNS is configured.
- http_json.c: expose staticDns in the wifi config get/set JSON.
- AT command group: DNS as a 4th field of the static-config command (new var_str32_4).
- Log the resolved DNS server on IP_EVENT_STA_GOT_IP.

A missing NVS key (devices upgraded from firmware without DNS support) is treated as blank and falls back to the gateway, so existing static-IP setups self-heal with no migration.

## Description:

as part of this PR are changes to unpublished web sources, adding here the patch for the reverse engineered sources. They might need to be adjusted to actual undisclosed sources.

**Related issue (if applicable):** fixes # (issue)

## Checklist:
- [x] The pull request is done against the latest master branch
- [x] The code change compiles without warnings
- [x] The code change are formatted (clang-format)
- [x] New and existing unit tests pass

Plase set Github secret _WOKWI_CLI_TOKEN_ to run CI unit test in Wokwi simulator  (https://docs.wokwi.com/wokwi-ci/github-actions)

_NOTE: The code change must pass CI. **Your PR cannot be merged unless CI pass**_
