### PR TITLE
Add configurable remote syslog logging (UDP/514)

### DIFF
--- a/components/logger/include/logger.h
+++ b/components/logger/include/logger.h
@@ -13,6 +13,24 @@
 void logger_init(void);
 
 /**
+ * @brief Callback invoked for every captured log line.
+ *
+ * Runs in the context of the logging task under the logger mutex, so the
+ * callback MUST NOT log or block: copy the line and return immediately.
+ *
+ * @param line formatted log line (not NUL-guaranteed beyond len)
+ * @param len  length of the line in bytes
+ */
+typedef void (*logger_line_cb_t)(const char* line, int len);
+
+/**
+ * @brief Register a single line callback (replaces any previous one).
+ *
+ * @param cb callback, or NULL to disable
+ */
+void logger_register_line_cb(logger_line_cb_t cb);
+
+/**
  * @brief Get log bugger lengt
  *
  * @return uint16_t

--- a/components/logger/src/logger.c
+++ b/components/logger/src/logger.c
@@ -23,6 +23,8 @@ static uint8_t s_log_buffer_data[LOG_BUFFER_SIZE];
 
 static output_buffer_t* s_log_buffer;
 
+static logger_line_cb_t s_line_cb = NULL;
+
 typedef struct {
     uint32_t magic;
     char log[PANIC_LOG_SIZE];
@@ -44,6 +46,10 @@ static int logger_vprintf(const char* str, va_list l)
     int len = vsnprintf(log, LOG_LINE_SIZE, str, l);
 
     output_buffer_append_buf(s_log_buffer, log, len);
+
+    if (s_line_cb != NULL) {
+        s_line_cb(log, len);
+    }
 
     xSemaphoreGive(s_mutex);
 
@@ -76,6 +82,11 @@ bool logger_log_bugger_read(uint16_t* index, char** str, uint16_t* len)
     xSemaphoreGive(s_mutex);
 
     return has_next;
+}
+
+void logger_register_line_cb(logger_line_cb_t cb)
+{
+    s_line_cb = cb;
 }
 
 time_t logger_get_panic_time(void)

--- a/components/protocols/CMakeLists.txt
+++ b/components/protocols/CMakeLists.txt
@@ -6,4 +6,4 @@ idf_component_register(SRC_DIRS "src"
                     PRIV_INCLUDE_DIRS "src"
                     EMBED_FILES "${embed_files}"
                     PRIV_REQUIRES nvs_flash esp_http_server esp_wifi esp_timer esp_https_ota driver app_update cjson vfs littlefs mbedtls
-                    REQUIRES config restart network modbus script serial logger)
+                    REQUIRES config restart network modbus script serial logger syslog)

--- a/components/protocols/src/http_json.c
+++ b/components/protocols/src/http_json.c
@@ -25,6 +25,7 @@
 #include "serial.h"
 #include "serial_nextion.h"
 #include "socket_lock.h"
+#include "syslog.h"
 #include "temp_sensor.h"
 #include "wifi.h"
 
@@ -57,6 +58,7 @@ cJSON* http_json_get_config(void)
     cJSON_AddItemToObject(json, "evse", http_json_get_config_evse());
     cJSON_AddItemToObject(json, "wifi", http_json_get_config_wifi());
     cJSON_AddItemToObject(json, "discovery", http_json_get_config_discovery());
+    cJSON_AddItemToObject(json, "syslog", http_json_get_config_syslog());
     cJSON_AddItemToObject(json, "serial", http_json_get_config_serial());
     cJSON_AddItemToObject(json, "modbus", http_json_get_config_modbus());
     cJSON_AddItemToObject(json, "script", http_json_get_config_script());
@@ -374,6 +376,27 @@ esp_err_t http_json_set_config_discovery(cJSON* json)
     }
 
     return written > 0 ? ESP_OK : ESP_ERR_INVALID_ARG;
+}
+
+cJSON* http_json_get_config_syslog(void)
+{
+    cJSON* json = cJSON_CreateObject();
+
+    cJSON_AddBoolToObject(json, "enabled", syslog_is_enabled());
+
+    char host[SYSLOG_HOST_SIZE];
+    syslog_get_host(host);
+    cJSON_AddStringToObject(json, "host", host);
+
+    return json;
+}
+
+esp_err_t http_json_set_config_syslog(cJSON* json)
+{
+    bool enabled = cJSON_IsTrue(cJSON_GetObjectItem(json, "enabled"));
+    char* host = cJSON_GetStringValue(cJSON_GetObjectItem(json, "host"));
+
+    return syslog_set_config(enabled, host);
 }
 
 cJSON* http_json_get_config_serial(void)

--- a/components/protocols/src/http_json.h
+++ b/components/protocols/src/http_json.h
@@ -25,6 +25,10 @@ cJSON* http_json_get_config_discovery(void);
 
 esp_err_t http_json_set_config_discovery(cJSON* json);
 
+cJSON* http_json_get_config_syslog(void);
+
+esp_err_t http_json_set_config_syslog(cJSON* json);
+
 cJSON* http_json_get_config_serial(void);
 
 esp_err_t http_json_set_config_serial(cJSON* json);

--- a/components/protocols/src/http_rest.c
+++ b/components/protocols/src/http_rest.c
@@ -42,6 +42,7 @@ typedef enum {
     URI_CONFIG_EVSE,
     URI_CONFIG_WIFI,
     URI_CONFIG_DISCOVERY,
+    URI_CONFIG_SYSLOG,
     URI_CONFIG_SERIAL,
     URI_CONFIG_MODBUS,
     URI_CONFIG_SCRIPT,
@@ -86,6 +87,7 @@ static const char* uris[] = {
     "/config/evse",
     "/config/wifi",
     "/config/discovery",
+    "/config/syslog",
     "/config/serial",
     "/config/modbus",
     "/config/script",
@@ -557,6 +559,8 @@ static esp_err_t get_handler(httpd_req_t* req)
             return handle_json_response(req, http_json_get_config_wifi());
         case URI_CONFIG_DISCOVERY:
             return handle_json_response(req, http_json_get_config_discovery());
+        case URI_CONFIG_SYSLOG:
+            return handle_json_response(req, http_json_get_config_syslog());
         case URI_CONFIG_SERIAL:
             return handle_json_response(req, http_json_get_config_serial());
         case URI_CONFIG_MODBUS:
@@ -631,6 +635,8 @@ static esp_err_t post_handler(httpd_req_t* req)
             return handle_json_request(req, http_json_set_config_wifi);
         case URI_CONFIG_DISCOVERY:
             return handle_json_request(req, http_json_set_config_discovery);
+        case URI_CONFIG_SYSLOG:
+            return handle_json_request(req, http_json_set_config_syslog);
         case URI_WIFI_STATE_AP:
             return handle_json_request(req, http_json_set_wifi_state_ap);
         case URI_CONFIG_SERIAL:

--- a/components/syslog/CMakeLists.txt
+++ b/components/syslog/CMakeLists.txt
@@ -1,0 +1,4 @@
+idf_component_register(SRC_DIRS "src"
+                    INCLUDE_DIRS "include"
+                    PRIV_REQUIRES nvs_flash
+                    REQUIRES logger network)

--- a/components/syslog/include/syslog.h
+++ b/components/syslog/include/syslog.h
@@ -1,0 +1,36 @@
+#ifndef SYSLOG_H_
+#define SYSLOG_H_
+
+#include <esp_err.h>
+#include <stdbool.h>
+
+#define SYSLOG_HOST_SIZE 64
+
+/**
+ * @brief Initialize remote syslog: open NVS, create queue + sender task,
+ *        register the logger line callback. Call after network_init().
+ */
+void syslog_init(void);
+
+/**
+ * @brief Whether remote syslog forwarding is enabled.
+ */
+bool syslog_is_enabled(void);
+
+/**
+ * @brief Get configured syslog server host into a SYSLOG_HOST_SIZE buffer.
+ *
+ * @param value buffer of at least SYSLOG_HOST_SIZE bytes
+ */
+void syslog_get_host(char* value);
+
+/**
+ * @brief Set and persist syslog config. Applies live (no reboot).
+ *
+ * @param enabled enable/disable forwarding
+ * @param host    server host/IP (may be NULL to leave unchanged)
+ * @return ESP_OK or ESP_ERR_INVALID_ARG if host too long
+ */
+esp_err_t syslog_set_config(bool enabled, const char* host);
+
+#endif /* SYSLOG_H_ */

--- a/components/syslog/src/syslog.c
+++ b/components/syslog/src/syslog.c
@@ -1,0 +1,256 @@
+#include "syslog.h"
+
+#include <esp_log.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/queue.h>
+#include <freertos/semphr.h>
+#include <freertos/task.h>
+#include <lwip/netdb.h>
+#include <lwip/sockets.h>
+#include <nvs.h>
+#include <string.h>
+#include <time.h>
+
+#include "discovery.h"
+#include "logger.h"
+
+#define NVS_NAMESPACE "syslog"
+#define NVS_ENABLED   "enabled"
+#define NVS_HOST      "host"
+
+#define SYSLOG_PORT        514
+#define SYSLOG_FACILITY    1  // RFC 3164 facility "user"
+#define SYSLOG_QUEUE_LEN   16
+#define SYSLOG_PACKET_SIZE 600
+
+static const char* TAG = "syslog";
+
+static nvs_handle_t nvs;
+static SemaphoreHandle_t s_cfg_mutex;
+
+static volatile bool s_enabled;
+static char s_host[SYSLOG_HOST_SIZE];
+
+static QueueHandle_t s_queue;
+static int s_sock = -1;
+static struct sockaddr_in s_dest;
+static bool s_dest_valid;
+static volatile bool s_cfg_dirty;
+
+static void syslog_line_cb(const char* line, int len)
+{
+    if (!s_enabled || s_queue == NULL) {
+        return;
+    }
+
+    char* copy = malloc(len + 1);
+    if (copy == NULL) {
+        return;
+    }
+    memcpy(copy, line, len);
+    copy[len] = '\0';
+
+    if (xQueueSend(s_queue, &copy, 0) != pdTRUE) {
+        free(copy);  // queue full: drop the newest line, never block logging
+    }
+}
+
+static int severity_from_line(const char* line)
+{
+    const char* p = line;
+    if (*p == '\033') {  // skip leading ANSI color escape: ESC [ ... m
+        while (*p != '\0' && *p != 'm') {
+            p++;
+        }
+        if (*p == 'm') {
+            p++;
+        }
+    }
+    switch (*p) {
+    case 'E':
+        return 3;  // err
+    case 'W':
+        return 4;  // warning
+    case 'I':
+        return 6;  // info
+    case 'D':
+    case 'V':
+        return 7;  // debug
+    default:
+        return 6;  // info
+    }
+}
+
+static void strip_line(const char* src, char* dst, size_t dst_size)
+{
+    size_t i = 0;
+    size_t j = 0;
+    while (src[i] != '\0' && j < dst_size - 1) {
+        if (src[i] == '\033') {  // drop ANSI color escape sequence: ESC ... 'm'
+            while (src[i] != '\0' && src[i] != 'm') {
+                i++;
+            }
+            if (src[i] != '\0') {
+                i++;  // also drop the trailing 'm'
+            }
+        } else if (src[i] == '\n' || src[i] == '\r') {
+            i++;
+        } else {
+            dst[j++] = src[i];
+            i++;
+        }
+    }
+    dst[j] = '\0';
+}
+
+static int format_packet(char* buf, size_t buf_size, const char* line)
+{
+    int pri = SYSLOG_FACILITY * 8 + severity_from_line(line);
+
+    char ts[32];
+    time_t now = time(NULL);
+    struct tm tm_info;
+    localtime_r(&now, &tm_info);
+    strftime(ts, sizeof(ts), "%b %e %H:%M:%S", &tm_info);
+
+    char hostname[DISCOVERY_NAME_SIZE];
+    discovery_get_hostname(hostname);
+
+    char msg[SYSLOG_PACKET_SIZE];
+    strip_line(line, msg, sizeof(msg));
+
+    return snprintf(buf, buf_size, "<%d>%s %s evse: %s", pri, ts, hostname, msg);
+}
+
+static void resolve_dest(void)
+{
+    s_dest_valid = false;
+
+    char host[SYSLOG_HOST_SIZE];
+    syslog_get_host(host);
+    if (host[0] == '\0') {
+        return;
+    }
+
+    struct addrinfo hints = { .ai_family = AF_INET, .ai_socktype = SOCK_DGRAM };
+    struct addrinfo* res = NULL;
+    if (getaddrinfo(host, NULL, &hints, &res) != 0 || res == NULL) {
+        return;
+    }
+
+    struct sockaddr_in* addr = (struct sockaddr_in*)res->ai_addr;
+    s_dest.sin_family = AF_INET;
+    s_dest.sin_port = htons(SYSLOG_PORT);
+    s_dest.sin_addr = addr->sin_addr;
+    s_dest_valid = true;
+
+    freeaddrinfo(res);
+}
+
+static void send_line(const char* line)
+{
+    if (!s_enabled) {
+        return;
+    }
+
+    if (s_cfg_dirty) {
+        resolve_dest();
+        s_cfg_dirty = false;
+    }
+    if (!s_dest_valid) {
+        return;
+    }
+
+    if (s_sock < 0) {
+        s_sock = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+    }
+    if (s_sock < 0) {
+        return;
+    }
+
+    char packet[SYSLOG_PACKET_SIZE];
+    int len = format_packet(packet, sizeof(packet), line);
+    if (len <= 0) {
+        return;
+    }
+    if (len >= (int)sizeof(packet)) {
+        len = sizeof(packet) - 1;
+    }
+
+    int sent = sendto(s_sock, packet, len, 0, (struct sockaddr*)&s_dest, sizeof(s_dest));
+    if (sent < 0) {
+        s_cfg_dirty = true;  // force re-resolve next time
+    }
+}
+
+static void syslog_task(void* arg)
+{
+    char* line;
+    while (true) {
+        if (xQueueReceive(s_queue, &line, portMAX_DELAY) == pdTRUE) {
+            send_line(line);
+            free(line);
+        }
+    }
+}
+
+void syslog_init(void)
+{
+    ESP_ERROR_CHECK(nvs_open(NVS_NAMESPACE, NVS_READWRITE, &nvs));
+
+    s_cfg_mutex = xSemaphoreCreateMutex();
+
+    uint8_t enabled = false;
+    nvs_get_u8(nvs, NVS_ENABLED, &enabled);
+    s_enabled = enabled;
+
+    size_t len = SYSLOG_HOST_SIZE;
+    s_host[0] = '\0';
+    nvs_get_str(nvs, NVS_HOST, s_host, &len);
+
+    s_cfg_dirty = true;
+
+    s_queue = xQueueCreate(SYSLOG_QUEUE_LEN, sizeof(char*));
+    xTaskCreate(syslog_task, "syslog", 4096, NULL, 5, NULL);
+
+    logger_register_line_cb(syslog_line_cb);
+
+    ESP_LOGI(TAG, "Syslog init: enabled=%d host='%s'", s_enabled, s_host);
+}
+
+bool syslog_is_enabled(void)
+{
+    return s_enabled;
+}
+
+void syslog_get_host(char* value)
+{
+    xSemaphoreTake(s_cfg_mutex, portMAX_DELAY);
+    snprintf(value, SYSLOG_HOST_SIZE, "%s", s_host);
+    xSemaphoreGive(s_cfg_mutex);
+}
+
+esp_err_t syslog_set_config(bool enabled, const char* host)
+{
+    if (host != NULL && strnlen(host, SYSLOG_HOST_SIZE) >= SYSLOG_HOST_SIZE) {
+        ESP_LOGE(TAG, "Host out of range");
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    nvs_set_u8(nvs, NVS_ENABLED, enabled);
+    if (host != NULL) {
+        nvs_set_str(nvs, NVS_HOST, host);
+    }
+    nvs_commit(nvs);
+
+    xSemaphoreTake(s_cfg_mutex, portMAX_DELAY);
+    if (host != NULL) {
+        snprintf(s_host, sizeof(s_host), "%s", host);
+    }
+    s_enabled = enabled;
+    s_cfg_dirty = true;
+    xSemaphoreGive(s_cfg_mutex);
+
+    ESP_LOGI(TAG, "Syslog config changed: enabled=%d host='%s'", enabled, s_host);
+    return ESP_OK;
+}

--- a/main/main.c
+++ b/main/main.c
@@ -24,6 +24,7 @@
 #include "protocols.h"
 #include "script.h"
 #include "serial.h"
+#include "syslog.h"
 #include "wifi.h"
 
 #define AP_CONNECTION_TIMEOUT 60000  // 60sec
@@ -320,6 +321,7 @@ void app_main(void)
     board_config_load(init_count > 5);
 
     network_init();
+    syslog_init();
     peripherals_init();
     modbus_init();
     serial_init();

--- a/remote-syslog-webui.patch
+++ b/remote-syslog-webui.patch
@@ -1,0 +1,208 @@
+--- a/components/protocols/web/src/pages/NetworkSettings.jsx
++++ b/components/protocols/web/src/pages/NetworkSettings.jsx
+@@ -81,6 +81,7 @@
+   const [loading, setLoading] = useState(true);
+   const [wifiFormData, setWifiFormData] = useState(); // /config/wifi
+   const [discoveryFormData, setDiscoveryFormData] = useState(); // /config/discovery
++  const [syslogFormData, setSyslogFormData] = useState(); // /config/syslog
+   const [wifiState, setWifiState] = useState(); // /wifi/state
+ 
+   const fetchJsonResp = fetchJson(); // u = Ne()
+@@ -95,6 +96,9 @@
+       fetch("/api/v1/config/wifi", { signal: abortController.signal })
+         .then(fetchJsonResp)
+         .then(setWifiFormData),
++      fetch("/api/v1/config/syslog", { signal: abortController.signal })
++        .then(fetchJsonResp)
++        .then(setSyslogFormData),
+       fetch("/api/v1/wifi/state", { signal: abortController.signal })
+         .then(fetchJsonResp)
+         .then(setWifiState),
+@@ -124,6 +128,13 @@
+             state={wifiState}
+             formData={wifiFormData}
+             setFormData={setWifiFormData}
++          />
++          {/* Remote syslog: enable + server host */}
++          <SyslogSection
++            setLoading={setLoading}
++            abortController={abortController}
++            formData={syslogFormData}
++            setFormData={setSyslogFormData}
+           />
+           {/* Discovery: hostname + instance name */}
+           <DiscoverySection
+@@ -572,4 +583,96 @@
+   );
+ };
+ 
++const SyslogSection = ({ setLoading, abortController, formData, setFormData }) => {
++  const t = useTranslation();
++  const [validated, setValidated] = useState(false);
++
++  const fetchJsonResp = fetchJson();
++  const fetchVoidResp = fetchVoid();
++  const handleApiError = useApiErrorHandler();
++  const onChange = createChangeHandler(setFormData);
++  const toast = useToast();
++
++  // Submit -> POST /config/syslog
++  const onSubmit = (e) => {
++    e.preventDefault();
++    if (e.currentTarget.checkValidity()) {
++      setLoading(true);
++      fetch("/api/v1/config/syslog", {
++        method: "POST",
++        headers: { "Content-Type": "application/json" },
++        body: JSON.stringify(formData),
++        signal: abortController.signal,
++      })
++        .then(fetchVoidResp)
++        .then(() => toast.success(t("successfullyUpdated")))
++        .finally(() => {
++          setLoading(false);
++          setValidated(false);
++        })
++        .catch(handleApiError);
++    } else {
++      setValidated(true);
++    }
++  };
++
++  // Reset -> re-fetch /config/syslog
++  const onReset = (e) => {
++    e.preventDefault();
++    setLoading(true);
++    fetch("/api/v1/config/syslog", { signal: abortController.signal })
++      .then(fetchJsonResp)
++      .then(setFormData)
++      .finally(() => {
++        setLoading(false);
++        setValidated(false);
++      })
++      .catch(handleApiError);
++  };
++
++  return (
++    <div>
++      <h5 className="mt-3">{t("syslog")}</h5>
++      <Form noValidate validated={validated} onSubmit={onSubmit} onReset={onReset}>
++        <Row>
++          <Col xs={12}>
++            <Form.Check
++              type="switch"
++              id="syslogEnabled"
++              name="enabled"
++              className="mb-3"
++              checked={formData?.enabled}
++              onChange={onChange}
++              label={t("enabled")}
++            />
++          </Col>
++        </Row>
++        <Row>
++          <Col xs={12} md={6} xl={4}>
++            <Form.Group className="mb-3" controlId="syslogHost">
++              <Form.Label>{t("syslogHost")}</Form.Label>
++              <Form.Control
++                name="host"
++                required={formData?.enabled === true}
++                disabled={formData?.enabled !== true}
++                placeholder="192.168.1.10"
++                value={formData?.host}
++                onChange={onChange}
++              />
++            </Form.Group>
++          </Col>
++        </Row>
++        <Stack gap={2} direction="horizontal">
++          <Button variant="primary" type="submit">
++            {t("submit")}
++          </Button>
++          <Button variant="secondary" type="reset">
++            {t("reset")}
++          </Button>
++        </Stack>
++      </Form>
++    </div>
++  );
++};
++
+ export default NetworkSettings;
+--- a/components/protocols/web/src/locales/en.json
++++ b/components/protocols/web/src/locales/en.json
+@@ -196,6 +196,8 @@
+   "discovery": "Discovery",
+   "hostname": "Hostname",
+   "instanceName": "Instance name",
++  "syslog": "Remote syslog",
++  "syslogHost": "Syslog server",
+   "rssi": "RSSI",
+   "panicReboot": "Panic reboot",
+   "acknowledge": "Acknowledge",
+--- a/components/protocols/web/src/locales/cz.json
++++ b/components/protocols/web/src/locales/cz.json
+@@ -196,6 +196,8 @@
+   "discovery": "Objevování",
+   "hostname": "Název hostitele",
+   "instanceName": "Název instance",
++  "syslog": "Vzdálený syslog",
++  "syslogHost": "Syslog server",
+   "rssi": "RSSI",
+   "panicReboot": "Panický reštart",
+   "acknowledge": "Potvrdit",
+--- a/components/protocols/web/src/locales/sk.json
++++ b/components/protocols/web/src/locales/sk.json
+@@ -196,6 +196,8 @@
+   "discovery": "Objavovanie",
+   "hostname": "Názov hostiteľa",
+   "instanceName": "Názov inštancie",
++  "syslog": "Vzdialený syslog",
++  "syslogHost": "Syslog server",
+   "rssi": "RSSI",
+   "panicReboot": "Panický reštart",
+   "acknowledge": "Potvrdiť",
+--- a/components/protocols/web/src/locales/fr.json
++++ b/components/protocols/web/src/locales/fr.json
+@@ -196,6 +196,8 @@
+   "discovery": "Découverte",
+   "hostname": "Nom d'hôte",
+   "instanceName": "Nom de l'instance",
++  "syslog": "Syslog distant",
++  "syslogHost": "Serveur syslog",
+   "rssi": "RSSI",
+   "panicReboot": "Redémarrage panique",
+   "acknowledge": "Acquitter",
+--- a/components/protocols/web/src/locales/hu.json
++++ b/components/protocols/web/src/locales/hu.json
+@@ -196,6 +196,8 @@
+   "discovery": "Felfedezés",
+   "hostname": "Gépnév",
+   "instanceName": "Eszköznév",
++  "syslog": "Távoli syslog",
++  "syslogHost": "Syslog kiszolgáló",
+   "rssi": "RSSI",
+   "panicReboot": "Pánik újraindítás",
+   "acknowledge": "Nyugtázás",
+--- a/components/protocols/web/src/locales/ru.json
++++ b/components/protocols/web/src/locales/ru.json
+@@ -196,6 +196,8 @@
+   "discovery": "Обнаружение",
+   "hostname": "Имя хоста",
+   "instanceName": "Имя экземпляра",
++  "syslog": "Удалённый syslog",
++  "syslogHost": "Сервер syslog",
+   "rssi": "RSSI",
+   "panicReboot": "Паника перезагрузка",
+   "acknowledge": "Подтвердить",
+--- a/components/protocols/web/src/locales/tr.json
++++ b/components/protocols/web/src/locales/tr.json
+@@ -196,6 +196,8 @@
+   "discovery": "Keşif (Discovery)",
+   "hostname": "Ana bilgisayar adı",
+   "instanceName": "Örnek adı",
++  "syslog": "Uzak syslog",
++  "syslogHost": "Syslog sunucusu",
+   "rssi": "Sinyal Gücü (RSSI)",
+   "panicReboot": "Panik yeniden başlatma",
+   "acknowledge": "Onayla",


### PR DESCRIPTION
Forward ESP_LOG* lines to a user-configured remote syslog server over UDP port 514 (RFC 3164), toggled from /settings/network.

- New components/syslog: NVS config (enabled + host), a FreeRTOS queue fed by the logger callback, and a sender task that frames RFC 3164 packets (facility "user", severity mapped from the ESP log level) and sendto()s them. Drop-newest on a full queue so logging never blocks.
- logger: add logger_register_line_cb() so a consumer can receive every captured line without logger depending on the network stack.
- protocols: REST GET/POST /api/v1/config/syslog + aggregate config.
- main: syslog_init() after network_init().

Web UI sources are not tracked; the change is captured in remote-syslog-webui.patch (NetworkSettings.jsx + locales), placed between the Static IP and Discovery sections. web.cpio is intentionally not committed (rebuilt from the patch).

## Description:
as part of this PR are changes to unpublished web sources, adding here the patch for the reverse engineered sources. They might need to be adjusted to actual undisclosed sources.

**Related issue (if applicable):** fixes # (issue)

## Checklist:
- [x] The pull request is done against the latest master branch
- [x] The code change compiles without warnings
- [x] The code change are formatted (clang-format)
- [x] New and existing unit tests pass

Plase set Github secret _WOKWI_CLI_TOKEN_ to run CI unit test in Wokwi simulator  (https://docs.wokwi.com/wokwi-ci/github-actions)

_NOTE: The code change must pass CI. **Your PR cannot be merged unless CI pass**_
